### PR TITLE
expose the model name when a DataError occurs

### DIFF
--- a/django_scrubber/management/commands/scrub_data.py
+++ b/django_scrubber/management/commands/scrub_data.py
@@ -4,7 +4,7 @@ import logging
 
 from django.conf import settings
 from django.db.models import F
-from django.db.utils import IntegrityError
+from django.db.utils import IntegrityError, DataError
 from django.core.management.base import BaseCommand, CommandError
 from django.apps import apps
 
@@ -63,6 +63,8 @@ class Command(BaseCommand):
             except IntegrityError as e:
                 raise CommandError('Integrity error while scrubbing %s (%s); maybe increase '
                                    'SCRUBBER_ENTRIES_PER_PROVIDER?' % (model, e))
+            except DataError as e:
+                raise CommandError('DataError while scrubbing %s (%s)' % (model, e))
 
 
 def _call_callables(d):


### PR DESCRIPTION
Sometimes during development, or when a new field is added to the db and a global scrubber matches it, a DataBase error can occur, eg. because the field is too small to contain the anonymized data.

It is useful to know which model contains the field that is causing the problem.