### PR TITLE
skip proxy models

### DIFF
--- a/django_scrubber/management/commands/scrub_data.py
+++ b/django_scrubber/management/commands/scrub_data.py
@@ -48,6 +48,8 @@ class Command(BaseCommand):
             models = apps.get_models()
 
         for model in models:
+            if model._meta.proxy:
+                continue
             if settings_with_fallback('SCRUBBER_SKIP_UNMANAGED') and not model._meta.managed:
                 continue
             if (settings_with_fallback('SCRUBBER_APPS_LIST') and


### PR DESCRIPTION
Currently django-scrubber fails when trying to scrub a proxy model, printing an error about not being able to find the mod_pk field.
There is no need to scrub django proxy models as they have no corresponding db table.

Please let me know if there's anything else I can do.