### PR TITLE
install extra requirements for python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
     install_requires=[
         "django-model-utils>=2.0",
     ],
+    extras_require={":python_version<'3'": ["future>=0.16.0"]},
     license="BSD",
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
django-scrubber/django_scrubber/scrubbers.py is using the "builtins" module, but it (builtins) is not a built-in module in python 2. 
builtins in python2 is provided by the "future" pypi package, so I've added a conditional requirement for it.
Thank you