### PR TITLE
Add SameLengthText scrubber

### DIFF
--- a/tests/test_scrub_data.py
+++ b/tests/test_scrub_data.py
@@ -1,3 +1,7 @@
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils.six import StringIO
@@ -22,9 +26,26 @@ class TestScrubData(TestCase):
         err = StringIO()
 
         with self.settings(DEBUG=False):
-            call_command('scrub_data', stderr=err)
+            call_command('scrub_data',  stderr=err)
         output = err.getvalue()
         self.user.refresh_from_db()
 
         self.assertIn("this command should only be run with DEBUG=True, to avoid running on live systems", output)
         self.assertEqual(self.user.first_name, 'test_first_name')
+
+    def test_hash_simple_global_scrubber(self):
+        with self.settings(DEBUG=True, SCRUBBER_GLOBAL_SCRUBBERS={'first_name': scrubbers.Hash}):
+            call_command('scrub_data')
+        self.user.refresh_from_db()
+
+        self.assertNotEqual(self.user.first_name, 'test_first_name')
+
+    def test_hash_simple_class_scrubber(self):
+        class Scrubbers:
+            first_name = scrubbers.Hash
+
+        with self.settings(DEBUG=True), patch.object(User, 'Scrubbers', Scrubbers, create=True):
+            call_command('scrub_data')
+        self.user.refresh_from_db()
+
+        self.assertNotEqual(self.user.first_name, 'test_first_name')


### PR DESCRIPTION
This adds a scrubber that scrubs a field maintaining the field original text length.