### PR TITLE
Properly delete fake cache before provisioning

### DIFF
--- a/django_scrubber/scrubbers.py
+++ b/django_scrubber/scrubbers.py
@@ -130,7 +130,7 @@ class Faker(object):
                     provider_name)
             faker_instance.add_provider(provider)
 
-        provider_args_str = ', '.join(str(i) for i in sef.provider_args)
+        provider_args_str = ', '.join(str(i) for i in self.provider_args)
         provider_kwargs_str = ', '.join(str(i) for i in self.provider_kwargs)
         logger.info('Initializing fake scrub data for provider %s(%s, %s)' %
             (self.provider, provider_args_str, provider_kwargs_str)

--- a/django_scrubber/scrubbers.py
+++ b/django_scrubber/scrubbers.py
@@ -130,9 +130,13 @@ class Faker(object):
                     provider_name)
             faker_instance.add_provider(provider)
 
-        logger.info('Initializing fake scrub data for provider %s' % self.provider)
+        provider_args_str = ', '.join(str(i) for i in sef.provider_args)
+        provider_kwargs_str = ', '.join(str(i) for i in self.provider_kwargs)
+        logger.info('Initializing fake scrub data for provider %s(%s, %s)' %
+            (self.provider, provider_args_str, provider_kwargs_str)
+        )
         # TODO: maybe be a bit smarter and only regenerate if needed?
-        FakeData.objects.filter(provider=self.provider).delete()
+        FakeData.objects.filter(provider=self.provider_key).delete()
         fakedata = []
 
         # if we don't reset the seed for each provider, registering a new one might change all

--- a/tests/models.py
+++ b/tests/models.py
@@ -9,6 +9,7 @@ class DataToBeScrubbed(models.Model):
     description = models.TextField()
     ean8 = models.CharField(max_length=13)
     date_past = models.DateField(null=True)
+    company = models.CharField(max_length=255)
 
 
 class DataFactory(DjangoModelFactory):

--- a/tests/test_scrubbers.py
+++ b/tests/test_scrubbers.py
@@ -51,7 +51,7 @@ class TestScrubbers(TestCase):
             call_command('scrub_data')
         data.refresh_from_db()
 
-        # The EAN Faker will by default emit ean13, so this should fail if the parameter was ignored
+        # The EAN Faker will by default emit ean13, so this would fail if the parameter was ignored
         self.assertEquals(8, len(data.ean8))
 
         # Add a new scrubber for ean13
@@ -76,3 +76,17 @@ class TestScrubbers(TestCase):
 
             self.assertGreater(date.today(), data.date_past)
             self.assertLess(date.today() - timedelta(days=31), data.date_past)
+
+    def test_faker_scrubber_run_twice(self):
+        """
+        Use this as an example of what happens when you want to run the same Faker scrubbers twice
+        """
+        data = DataFactory.create(company='Foo')
+        with self.settings(DEBUG=True, SCRUBBER_GLOBAL_SCRUBBERS={
+                'company': scrubbers.Faker('company')}):
+            call_command('scrub_data')
+            call_command('scrub_data')
+        data.refresh_from_db()
+
+        self.assertNotEqual(data.company, 'Foo')
+        self.assertNotEqual(data.company, '')


### PR DESCRIPTION
We seem to have forgotten changing the delete query to also use the provider_key.
Right now it's looking for self.provider and won't find anything to delete, which in turn will cause an error with the UniqueConstraint for provider/provider_offset

fixes #16 