### PR TITLE
Fixed bug with missing migrations on "DEFAULT_AUTO_FIELD"

### DIFF
--- a/django_scrubber/apps.py
+++ b/django_scrubber/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class DjangoScrubberConfig(AppConfig):
+    name = "django_scrubber"
+    verbose_name = _("Django Scrubber")
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
Hi @lociii & @costela 

when your project has a [DEFAULT_AUTO_FIELD](https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field) set to != `
DEFAULT_AUTO_FIELD = "django.db.models.AutoField"`, running `makemigrations` will create a migration. Setting this field type in the apps.py (which is django default to have one), fixes that.

Best  
Ronny