### PR TITLE
Add support for regular expressions in SCRUBBER_REQUIRED_FIELD_MODEL_WHITELIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ and booleans (usually) can't contain sensitive personal data. These fields will 
 
 Whitelists a list of models which will not be checked during `scrub_validation` and when 
 activating the strict mode. Defaults to the non-privacy-related Django base models.
+Items can either be full model names (e.g. `auth.Group`) or regular expression patterns matching
+against the full model name (e.g. `re.compile(auth.*)` to whitelist all auth models).
 
 (default: ['auth.Group', 'auth.Permission', 'contenttypes.ContentType', 'sessions.Session', 'sites.Site', 
 'django_scrubber.FakeData',))

--- a/django_scrubber/services/validator.py
+++ b/django_scrubber/services/validator.py
@@ -1,4 +1,5 @@
 import re
+from typing import Union
 
 from django.apps import apps
 
@@ -11,7 +12,7 @@ class ScrubberValidatorService:
     """
 
     @staticmethod
-    def check_pattern(pattern: str | re.Pattern, value):
+    def check_pattern(pattern: Union[str, re.Pattern], value):
         if isinstance(pattern, str):
             return pattern == value
         elif isinstance(pattern, re.Pattern):

--- a/django_scrubber/services/validator.py
+++ b/django_scrubber/services/validator.py
@@ -1,3 +1,5 @@
+import re
+
 from django.apps import apps
 
 from django_scrubber import settings_with_fallback
@@ -7,6 +9,15 @@ class ScrubberValidatorService:
     """
     Service to validate if all text-based fields are being scrubbed within your project and dependencies.
     """
+
+    @staticmethod
+    def check_pattern(pattern: str | re.Pattern, value):
+        if isinstance(pattern, str):
+            return pattern == value
+        elif isinstance(pattern, re.Pattern):
+            return pattern.fullmatch(value)
+        else:
+            raise ValueError("Invalid pattern type")
 
     def process(self) -> dict:
         from django_scrubber.management.commands.scrub_data import _get_model_scrubbers
@@ -24,7 +35,10 @@ class ScrubberValidatorService:
         for model in model_list:
 
             # Check if model is whitelisted
-            if model._meta.label in model_whitelist:
+            if any(
+                self.check_pattern(pattern, model._meta.label)
+                for pattern in model_whitelist
+            ):
                 continue
 
             text_based_fields = []

--- a/tests/services/test_validator.py
+++ b/tests/services/test_validator.py
@@ -1,3 +1,5 @@
+import re
+
 try:
     from unittest import mock
 except ImportError:
@@ -62,3 +64,14 @@ class ScrubberValidatorServiceTest(TestCase):
         result = service.process()
 
         self.assertEqual(len(result), 0)
+
+    @override_settings(
+        SCRUBBER_REQUIRED_FIELD_MODEL_WHITELIST=[re.compile("auth.*")],
+    )
+    def test_process_scrubber_required_field_model_whitelist_regex(self):
+        service = ScrubberValidatorService()
+        result = service.process()
+
+        model_list = tuple(result.keys())
+        self.assertNotIn('auth.User', model_list)
+        self.assertNotIn('auth.Permission', model_list)

--- a/tests/test_scrubbers.py
+++ b/tests/test_scrubbers.py
@@ -79,7 +79,7 @@ class TestScrubbers(TestCase):
         data.refresh_from_db()
 
         # The EAN Faker will by default emit ean13, so this would fail if the parameter was ignored
-        self.assertEquals(8, len(data.ean8))
+        self.assertEqual(8, len(data.ean8))
 
         # Add a new scrubber for ean13
         with self.settings(DEBUG=True, SCRUBBER_GLOBAL_SCRUBBERS={'ean8': scrubbers.Faker('ean', length=13)}):
@@ -87,7 +87,7 @@ class TestScrubbers(TestCase):
         data.refresh_from_db()
 
         # make sure it doesn't reuse the ean with length=8 scrubber
-        self.assertEquals(13, len(data.ean8))
+        self.assertEqual(13, len(data.ean8))
 
     def test_faker_scrubber_datefield(self):
         """


### PR DESCRIPTION
Adds support for regular expressions when whitelisting models for validation as discussed [here](https://github.com/RegioHelden/django-scrubber/issues/53).