### PR TITLE
Removed `SCRUBBER_VALIDATION_WHITELIST` in favour of exiting whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!--
 ## [Unreleased]
 
-- 
+- Removed `SCRUBBER_VALIDATION_WHITELIST` in favour of `SCRUBBER_REQUIRED_FIELD_MODEL_WHITELIST`
+- Added Django test model `db.TestModel` to default whitelist of `SCRUBBER_REQUIRED_FIELD_MODEL_WHITELIST`
 -->
 
 ## [2.1.0] - 2024-08-20

--- a/README.md
+++ b/README.md
@@ -311,8 +311,8 @@ activating the strict mode. Defaults to the non-privacy-related Django base mode
 Items can either be full model names (e.g. `auth.Group`) or regular expression patterns matching
 against the full model name (e.g. `re.compile(auth.*)` to whitelist all auth models).
 
-(default: ['auth.Group', 'auth.Permission', 'contenttypes.ContentType', 'sessions.Session', 'sites.Site', 
-'django_scrubber.FakeData',))
+(default: `('auth.Group', 'auth.Permission', 'contenttypes.ContentType', 'sessions.Session', 'sites.Site', 
+'django_scrubber.FakeData', 'db.TestModel',)`)
 
 ````python
 SCRUBBER_MAPPING = {
@@ -322,12 +322,6 @@ SCRUBBER_MAPPING = {
 
 (default: {})
 
-### `SCRUBBER_VALIDATION_WHITELIST`:
-
-Whitelist models you want to exclude from the `scrub_validation` checker command for scrubber-wise undeclared models.
-By default, it contains only a test model from Django core which doesn't have to be anonymised. 
-
-(default: ['db.TestModel',])
 
 ## Logging
 

--- a/django_scrubber/__init__.py
+++ b/django_scrubber/__init__.py
@@ -25,12 +25,10 @@ defaults = {
         'auth.Group',
         'auth.Permission',
         'contenttypes.ContentType',
+        'db.TestModel',
         'sessions.Session',
         'sites.Site',
         'django_scrubber.FakeData',
-    ],
-    'SCRUBBER_VALIDATION_WHITELIST': [
-        'db.TestModel',  # Test model from Django core
     ],
 }
 

--- a/django_scrubber/management/commands/scrub_validation.py
+++ b/django_scrubber/management/commands/scrub_validation.py
@@ -2,7 +2,6 @@ import sys
 
 from django.core.management.base import BaseCommand
 
-from django_scrubber import settings_with_fallback
 from django_scrubber.services.validator import ScrubberValidatorService
 
 
@@ -15,15 +14,8 @@ class Command(BaseCommand):
         found_models = 0
         found_fields = 0
 
-        whitelisted_models = settings_with_fallback('SCRUBBER_VALIDATION_WHITELIST')
-
         if len(non_scrubbed_field_list):
             for model_path, affected_field_list in non_scrubbed_field_list.items():
-
-                if model_path in whitelisted_models:
-                    print(f'Model {model_path!r} was excluded via \'SCRUBBER_VALIDATION_WHITELIST\' and will '
-                          'not be validated.')
-                    continue
 
                 print(f'Model {model_path!r}:')
                 found_models += 1


### PR DESCRIPTION
Hi @lociii 

while investigating a bug, I found a better way of handling this issue with this odd `db.TestModel`.

Best  
Ronny