### PR TITLE
Removed Python <3.3 mock imports from unit-test files

### DIFF
--- a/tests/services/test_validator.py
+++ b/tests/services/test_validator.py
@@ -1,9 +1,6 @@
 import re
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from django.test import override_settings, TestCase
 

--- a/tests/test_scrub_data.py
+++ b/tests/test_scrub_data.py
@@ -1,7 +1,4 @@
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 from io import StringIO
 
 from django.core.management import call_command

--- a/tests/test_scrub_validator.py
+++ b/tests/test_scrub_validator.py
@@ -1,9 +1,6 @@
 from django_scrubber.services.validator import ScrubberValidatorService
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from django.core.management import call_command
 from django.test import TestCase


### PR DESCRIPTION
Hi @lociii 

in order to get my new release, I have to fix more stuff, right? 😆 

Here's a tiny fix for Python <3.3 compat, which we don't support anymore.

Best from Cologne  
Ronny