### PR TITLE
Only fail validation with an non-zero exit code if strict mode is active

### DIFF
--- a/django_scrubber/management/commands/scrub_validation.py
+++ b/django_scrubber/management/commands/scrub_validation.py
@@ -2,6 +2,7 @@ import sys
 
 from django.core.management.base import BaseCommand
 
+from django_scrubber import settings_with_fallback
 from django_scrubber.services.validator import ScrubberValidatorService
 
 
@@ -24,7 +25,14 @@ class Command(BaseCommand):
 
             self.stdout.write("")
             if found_models > 0:
-                self.stdout.write(f"{found_models} model(s) having {found_fields} unscrubbed field(s) detected.")
-                sys.exit(1)
+                if settings_with_fallback("SCRUBBER_STRICT_MODE"):
+                    self.stdout.write(f"{found_models} model(s) having {found_fields} unscrubbed field(s) detected.")
+                    sys.exit(1)
+                else:
+                    self.stdout.write(
+                        f"{found_models} model(s) having {found_fields} unscrubbed field(s) detected."
+                        "However strict mode is deactivated and scrubbing is not enforced.",
+                    )
+                    sys.exit(0)
 
         self.stdout.write("No unscrubbed fields detected. Yeah!")

--- a/django_scrubber/management/commands/scrub_validation.py
+++ b/django_scrubber/management/commands/scrub_validation.py
@@ -24,15 +24,15 @@ class Command(BaseCommand):
                     found_fields += 1
 
             self.stdout.write("")
+
             if found_models > 0:
+                self.stdout.write(f"{found_models} model(s) having {found_fields} unscrubbed field(s) detected.")
+
+                # strict mode should fail with a non-zero exit code
                 if settings_with_fallback("SCRUBBER_STRICT_MODE"):
-                    self.stdout.write(f"{found_models} model(s) having {found_fields} unscrubbed field(s) detected.")
                     sys.exit(1)
-                else:
-                    self.stdout.write(
-                        f"{found_models} model(s) having {found_fields} unscrubbed field(s) detected."
-                        "However strict mode is deactivated and scrubbing is not enforced.",
-                    )
-                    sys.exit(0)
+
+                self.stdout.write("However strict mode is deactivated and scrubbing is not enforced.")
+                sys.exit(0)
 
         self.stdout.write("No unscrubbed fields detected. Yeah!")

--- a/django_scrubber/services/validator.py
+++ b/django_scrubber/services/validator.py
@@ -37,27 +37,27 @@ class ScrubberValidatorService:
             if any(self.check_pattern(pattern, model._meta.label) for pattern in model_whitelist):
                 continue
 
-            text_based_fields = []
+            fields_need_scrubbing = []
             # Get the model's name and fields
             fields = model._meta.get_fields()
 
-            # Gather list of all text-based files of the given model
+            # Gather list of all fields of the given model that require scrubbing
             for field in fields:
                 if type(field) in scrubber_required_field_types:
-                    text_based_fields.append(field.name)
+                    fields_need_scrubbing.append(field.name)
 
             # Get scrubber class
             scrubber_class = _get_model_scrubbers(model)
 
             # If we did find a scrubber class...
             if scrubber_class:
-                # We check for every text-based field, if it's set to be scrubbed
+                # We check for every scrubbing requiring field, if it's set to be scrubbed
                 for scrubbed_field in scrubber_class:
-                    if scrubbed_field.name in text_based_fields:
-                        text_based_fields.remove(scrubbed_field.name)
+                    if scrubbed_field.name in fields_need_scrubbing:
+                        fields_need_scrubbing.remove(scrubbed_field.name)
 
-            # Store per model all non-scrubbed, text-based fields
-            if len(text_based_fields) > 0:
-                non_scrubbed_field_list[model._meta.label] = text_based_fields
+            # Store per model all non-scrubbed but scrubbing requiring fields
+            if len(fields_need_scrubbing) > 0:
+                non_scrubbed_field_list[model._meta.label] = fields_need_scrubbing
 
         return non_scrubbed_field_list

--- a/django_scrubber/tests/test_scrub_validator.py
+++ b/django_scrubber/tests/test_scrub_validator.py
@@ -1,18 +1,48 @@
+from io import StringIO
 from unittest import mock
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from django_scrubber.services.validator import ScrubberValidatorService
 
 
 class TestScrubValidator(TestCase):
+    @override_settings(SCRUBBER_STRICT_MODE=False)
     def test_scrub_validator_regular(self):
-        with self.assertRaises(SystemExit):
-            call_command("scrub_validation", verbosity=3)
+        out = StringIO()
+
+        with self.assertRaises(SystemExit) as exc:
+            call_command(
+                "scrub_validation",
+                verbosity=3,
+                stdout=out,
+            )
+
+        self.assertEqual(exc.exception.code, 0)
+        self.assertIn("unscrubbed field(s) detected", out.getvalue())
+        self.assertIn("However strict mode is deactivated and scrubbing is not enforced.", out.getvalue())
+
+    @override_settings(SCRUBBER_STRICT_MODE=True)
+    def test_scrub_validator_strict_mode(self):
+        out = StringIO()
+
+        with self.assertRaises(SystemExit) as exc:
+            call_command(
+                "scrub_validation",
+                verbosity=3,
+                stdout=out,
+            )
+
+        self.assertEqual(exc.exception.code, 1)
+        self.assertIn("unscrubbed field(s) detected", out.getvalue())
+        self.assertNotIn("However strict mode is deactivated and scrubbing is not enforced.", out.getvalue())
 
     @mock.patch.object(ScrubberValidatorService, "process")
     def test_scrub_validator_service_called(self, mocked_method):
-        call_command("scrub_validation", verbosity=3)
+        out = StringIO()
+
+        call_command("scrub_validation", verbosity=3, stdout=out)
 
         mocked_method.assert_called_once()
+        self.assertIn("No unscrubbed fields detected. Yeah!", out.getvalue())


### PR DESCRIPTION
As we're starting to use scrubber validation in our CI pipelines, we need a way to tell if the scrubber setup is properly done. In our case that means:
- If strict mode is active, scrubbers for all models must be defined and the validation must succeed
- If strict mode is disabled, we don't want the validation to fail

So far the validation also failed with a non-zero exit code if strict mode was disabled but not all models were set up to be scrubbed.

This might be considered a backwards incompatible change as the exit behavior of the validation command gets changed.

@GitRon what's your thought as you implemented strict mode and validation?