### PR TITLE
Remove ambiguity around callables and a logical operator

### DIFF
--- a/django_scrubber/management/commands/scrub_data.py
+++ b/django_scrubber/management/commands/scrub_data.py
@@ -133,7 +133,7 @@ def _call_callables(d):
     """
     Helper to realize lazy scrubbers, like Faker, or global field-type scrubbers
     """
-    return {k.name: ((callable(v) and v(k)) or v) for k, v in d.items()}
+    return {k.name: (v(k) if callable(v) else v) for k, v in d.items()}
 
 
 def _parse_scrubber_class_from_string(path: str):

--- a/django_scrubber/tests/test_scrub_data.py
+++ b/django_scrubber/tests/test_scrub_data.py
@@ -22,6 +22,16 @@ class TestScrubData(TestCase):
 
         self.assertNotEqual(self.user.first_name, "test_first_name")
 
+    def test_scrub_data_callable_scrubber(self):
+        with self.settings(DEBUG=True, SCRUBBER_GLOBAL_SCRUBBERS={"first_name": scrubbers.Hash}):
+            call_command("scrub_data", stdout=StringIO())
+        self.user.refresh_from_db()
+
+        self.assertNotEqual(self.user.first_name, "test_first_name")
+
+        # make sure it's a md5 hash
+        self.assertRegex(self.user.first_name, "[a-f0-9]{32}")
+
     def test_scrub_data_debug_is_false(self):
         err = StringIO()
 


### PR DESCRIPTION
e.g. `True and Path("/")` still results in `Path("/")` but is pretty confusing.