### PR TITLE
Add conditional scrubber that only executes on non-empty fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ class Scrubbers:
     somefield = scrubbers.Lorem
 ```
 
+### IfNotEmpty
+
+Wrapper around another single scrubber that only cleans the field if it already contains data before cleaning.
+
+```python
+class Scrubbers:
+    somefield = scrubbers.IfNotEmpty(scrubbers.Lorem)
+
+class Scrubbers:
+    somefield = scrubbers.IfNotEmpty(scrubbers.Concat(scrubbers.Faker('city'), models.Value('@'), scrubbers.Faker('domain_name'), output_field=models.TextField()))
+```
+
 ### Concat
 
 Wrapper around `django.db.functions.Concat` to enable simple concatenation of scrubbers. This is useful if you want to

--- a/django_scrubber/tests/test_scrubbers.py
+++ b/django_scrubber/tests/test_scrubbers.py
@@ -194,3 +194,26 @@ class TestScrubbers(TestCase):
 
         # Assertion that the faker data was removed
         self.assertFalse(FakeData.objects.filter(provider="company", content="Foo").exists())
+
+    def test_ifnotempty_no_data(self):
+        data = DataFactory.create(description="")
+        with self.settings(
+            DEBUG=True,
+            SCRUBBER_GLOBAL_SCRUBBERS={"description": scrubbers.IfNotEmpty(scrubbers.Lorem)},
+        ):
+            call_command("scrub_data", stdout=StringIO())
+        data.refresh_from_db()
+
+        self.assertEqual(data.description, "")
+
+    def test_ifnotempty_has_data(self):
+        data = DataFactory.create(description="bla")
+        with self.settings(
+            DEBUG=True,
+            SCRUBBER_GLOBAL_SCRUBBERS={"description": scrubbers.IfNotEmpty(scrubbers.Lorem)},
+        ):
+            call_command("scrub_data", stdout=StringIO())
+        data.refresh_from_db()
+
+        self.assertNotEqual(data.description, "bla")
+        self.assertEqual(data.description[:11], "Lorem ipsum")


### PR DESCRIPTION
Sometimes I only want to scrub a field if it actually contained data before the scrubbing process.
For example, if a model contains a comment field, it should only be scrubbed if a comment existed previously. Otherwise, the field should remain empty.