### PR TITLE
Allow subclassing scrubbers

### DIFF
--- a/django_scrubber/management/commands/scrub_data.py
+++ b/django_scrubber/management/commands/scrub_data.py
@@ -1,5 +1,6 @@
 import importlib
 import warnings
+from inspect import getmembers
 
 from django.apps import apps
 from django.conf import settings
@@ -230,7 +231,7 @@ def _get_fields(d):
     Helper to get "normal" (i.e.: non-magic and non-dunder) instance attributes.
     Returns an iterator of (field_name, field) tuples.
     """
-    return ((k, v) for k, v in vars(d).items() if not k.startswith("_"))
+    return ((k, v) for k, v in getmembers(d) if not k.startswith("_"))
 
 
 def _filter_out_disabled(d):


### PR DESCRIPTION
Currently, if we extend a scrubber like so:

```python
class ModelA(models.Model):
    field_a = ...
    class Scrubbers:
        field_a = scrubbers.Keep

class ModelB(ModelA):
    field_b = ...
    class Scrubbers(ModelA.Scrubbers):
        field_b = scrubbers.Keep
```

only `field_b` of `ModelB` will be scrubbed, not `field_a`. In strict mode, this will fail.

By using `inspect.getmembers` instead of `vars`, this kind of scrubber extension will work.