### PR TITLE
Scrubber service wrapper with support for pre- and post scrub hooks, scrub_data command now exits non-zero on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,59 @@ Finally just run `./manage.py scrub_data` to **destructively** scrub the registe
 
 `--remove-fake-data` Will truncate the database table storing preprocessed data for the Faker library.
 
+## Customizing the scrubbing process
+
+Scrubbing the model fields is often only one part of anonymizing a database. You usually also want to run some
+custom logic around it, e.g. creating a known superuser to log in with, clearing caches, or resetting some
+project-specific tables. To make this pluggable, the `scrub_data` command delegates the whole process to a
+`ScrubberService`.
+
+The service is only about *behaviour*: subclass it and override the `pre_scrub` and/or `post_scrub` hooks to run
+custom logic around the scrubbing. It deliberately holds no configuration — what gets cleaned up is controlled
+through the `SCRUBBER_*` settings and the command-line arguments, just like everything else. This is entirely
+opt-in: if you don't configure a custom service, the default one is used and behaves exactly like before.
+
+```python
+# my_app/scrubbers.py
+from django.contrib.auth import get_user_model
+
+from django_scrubber.services.scrubber import ScrubberService
+
+
+class MyScrubberService(ScrubberService):
+    def pre_scrub(self):
+        # runs once *before* any data is scrubbed
+        ...
+
+    def post_scrub(self):
+        # runs once *after* all models have been scrubbed
+        self.create_superuser()
+        self.reset_something_else()
+
+    def create_superuser(self):
+        get_user_model().objects.create_superuser("admin", "admin@example.com", "admin")
+
+    def reset_something_else(self):
+        ...
+```
+
+Register your service via the `SCRUBBER_SERVICE_CLASS` setting:
+
+```python
+# settings.py
+SCRUBBER_SERVICE_CLASS = "my_app.scrubbers.MyScrubberService"
+```
+
+### Ordering of custom steps
+
+`pre_scrub` and `post_scrub` are plain methods, so you control the execution order simply by the order in which
+you call your steps inside them. There is intentionally no decorator-based registration — that would hide the
+order in which functions run and make it depend on definition order.
+
+The overall order is: `pre_scrub()` → scrub all model fields → `post_scrub()` → clear the Django admin log
+(if `SCRUBBER_CLEAR_DJANGO_ADMIN_LOG` is enabled) → truncate sessions (unless `--keep-sessions`) → truncate
+Faker source data (if `--remove-fake-data`).
+
 ## Built-In scrubbers
 
 ### Empty/Null
@@ -365,6 +418,27 @@ If your database vendor is not supported out of the box by the `Hash` scrubber (
 `SCRUBBER_HASH_TEMPLATE` defines an expression without length limitation, `SCRUBBER_HASH_TEMPLATE_MAX_LENGTH` must cut off at a specifc lengeht of `max_length`.
 
 (default: None)
+
+### `SCRUBBER_SERVICE_CLASS`:
+
+Dotted path to the service class orchestrating the `scrub_data` command. Point it at your own
+`ScrubberService` subclass to run custom logic before/after scrubbing or to change the cleanup behaviour.
+See [Customizing the scrubbing process](#customizing-the-scrubbing-process).
+
+(default: `"django_scrubber.services.scrubber.ScrubberService"`)
+
+### `SCRUBBER_CLEAR_DJANGO_ADMIN_LOG`:
+
+If `True`, the `django_admin_log` table (`django.contrib.admin.models.LogEntry`) is truncated after scrubbing.
+This table can contain user-related data (e.g. representations of changed objects), so you may want to clear it.
+
+This is **off by default on purpose**: historically `scrub_data` never touched the admin log, and turning it on
+by default would silently delete data for every existing project on upgrade. `django.contrib.admin` is not a
+dependency of this package; the `LogEntry` model is only imported when this setting is enabled. If it is enabled
+but `django.contrib.admin` is not in your `INSTALLED_APPS`, the cleanup is skipped with a warning instead of
+failing.
+
+(default: `False`)
 
 ## Logging
 

--- a/django_scrubber/__init__.py
+++ b/django_scrubber/__init__.py
@@ -30,6 +30,8 @@ defaults = {
     ),
     "SCRUBBER_HASH_TEMPLATE": None,
     "SCRUBBER_HASH_TEMPLATE_MAX_LENGTH": None,
+    "SCRUBBER_SERVICE_CLASS": "django_scrubber.services.scrubber.ScrubberService",
+    "SCRUBBER_CLEAR_DJANGO_ADMIN_LOG": False,
 }
 
 

--- a/django_scrubber/management/commands/scrub_data.py
+++ b/django_scrubber/management/commands/scrub_data.py
@@ -1,6 +1,5 @@
-import importlib
-
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.module_loading import import_string
 
 from django_scrubber import settings_with_fallback
 
@@ -22,9 +21,10 @@ def _get_scrubber_service_class() -> type[ScrubberService]:
     Resolve the scrubber service class configured via the ``SCRUBBER_SERVICE_CLASS`` setting.
     """
     path = settings_with_fallback("SCRUBBER_SERVICE_CLASS")
-    module_name, class_name = path.rsplit(".", 1)
-    module = importlib.import_module(module_name)
-    return getattr(module, class_name)
+    try:
+        return import_string(path)
+    except ImportError as e:
+        raise CommandError(f'SCRUBBER_SERVICE_CLASS "{path}" could not be imported: {e}') from e
 
 
 class Command(BaseCommand):
@@ -56,8 +56,13 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         service_class = _get_scrubber_service_class()
         service = service_class(stdout=self.stdout, stderr=self.stderr)
-        service.run(
+        if not service.run(
             model=kwargs.get("model"),
             keep_sessions=kwargs.get("keep_sessions", False),
             remove_fake_data=kwargs.get("remove_fake_data", False),
-        )
+        ):
+            # Preserve the historic contract: handle() returns False when the run was aborted
+            # (e.g. DEBUG is off or STRICT_MODE found undefined policies) so callers of
+            # call_command() can detect that nothing was scrubbed.
+            return False
+        return None

--- a/django_scrubber/management/commands/scrub_data.py
+++ b/django_scrubber/management/commands/scrub_data.py
@@ -1,50 +1,30 @@
 import importlib
-import warnings
-from inspect import getmembers
 
-from django.apps import apps
-from django.conf import settings
-from django.contrib.sessions.models import Session
-from django.core.exceptions import FieldDoesNotExist
-from django.core.management.base import BaseCommand, CommandError
-from django.db.models import F, IntegerField, Model
-from django.db.models.expressions import Func
-from django.db.utils import DataError, IntegrityError
+from django.core.management.base import BaseCommand
 
 from django_scrubber import settings_with_fallback
-from django_scrubber.models import FakeData
-from django_scrubber.scrubbers import Keep
-from django_scrubber.services.validator import ScrubberValidatorService
+
+# Re-exported for backwards compatibility: these used to live in this module and may be imported from here.
+from django_scrubber.services.scrubber import (  # noqa: F401
+    ScrubberService,
+    StringToInt,
+    _call_callables,
+    _filter_out_disabled,
+    _get_fields,
+    _get_model_scrubbers,
+    _parse_scrubber_class_from_string,
+    is_primary_key_integer,
+)
 
 
-class StringToInt(Func):
+def _get_scrubber_service_class() -> type[ScrubberService]:
     """
-    database-specific implementations for reproducible conversion of a field value to an integer
+    Resolve the scrubber service class configured via the ``SCRUBBER_SERVICE_CLASS`` setting.
     """
-
-    def as_sqlite(self, compiler, connection, **extra_context):
-        return self.as_sql(
-            compiler,
-            connection,
-            template="ABS(CAST(SUBSTR(UPPER(MD5(CAST(%(expressions)s AS VARCHAR))), 1, 16) AS BIGINT))",
-            **extra_context,
-        )
-
-    def as_mysql(self, compiler, connection, **extra_context):
-        return self.as_sql(
-            compiler,
-            connection,
-            template="ABS(CONV(SUBSTRING(MD5(CONCAT('x', %(expressions)s)), 1, 16), 16, 10))",
-            **extra_context,
-        )
-
-    def as_postgresql(self, compiler, connection, **extra_context):
-        return self.as_sql(
-            compiler,
-            connection,
-            template="ABS(CAST(CAST(('x' || MD5(CAST(%(expressions)s AS VARCHAR))) AS BIT(64)) AS BIGINT))",
-            **extra_context,
-        )
+    path = settings_with_fallback("SCRUBBER_SERVICE_CLASS")
+    module_name, class_name = path.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name)
 
 
 class Command(BaseCommand):
@@ -74,166 +54,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **kwargs):
-        if not settings.DEBUG:
-            # avoid logger, otherwise we might silently fail if we're on live and logging is being sent somewhere else
-            self.stderr.write("This command should only be run with DEBUG=True, to avoid running on live systems")
-            return False
-
-        # Check STRICT mode
-        if settings_with_fallback("SCRUBBER_STRICT_MODE"):
-            service = ScrubberValidatorService()
-            non_scrubbed_field_list = service.process()
-            if len(non_scrubbed_field_list) > 0:
-                self.stderr.write(
-                    'When "SCRUBBER_STRICT_MODE" is enabled, you have to define a scrubbing policy '
-                    "for every text-based field.",
-                )
-                return False
-
-        global_scrubbers = settings_with_fallback("SCRUBBER_GLOBAL_SCRUBBERS")
-
-        # run only for selected model
-        if kwargs.get("model") is not None:
-            app_label, model_name = kwargs.get("model").rsplit(".", 1)
-            try:
-                models = [apps.get_model(app_label=app_label, model_name=model_name)]
-            except LookupError as e:
-                raise CommandError("--model should be defined as <app_label>.<model_name>") from e
-
-        # run for all models of all apps
-        else:
-            models = apps.get_models()
-
-        scrubber_apps_list = settings_with_fallback("SCRUBBER_APPS_LIST")
-        for model_class in models:
-            self._scrub_model(model_class, scrubber_apps_list, global_scrubbers)
-
-        # Truncate session data
-        if not kwargs.get("keep_sessions", False):
-            Session.objects.all().delete()
-
-        # Truncate Faker data
-        if kwargs.get("remove_fake_data", False):
-            FakeData.objects.all().delete()
-            return None
-        return None
-
-    def _scrub_model(self, model_class, scrubber_apps_list, global_scrubbers):
-        if (
-            model_class._meta.proxy
-            or (settings_with_fallback("SCRUBBER_SKIP_UNMANAGED") and not model_class._meta.managed)
-            or (scrubber_apps_list and model_class._meta.app_config.name not in scrubber_apps_list)
-        ):
-            return
-
-        scrubbers = {}
-        for field in model_class._meta.fields:
-            if field.name in global_scrubbers:
-                scrubbers[field] = global_scrubbers[field.name]
-            elif type(field) in global_scrubbers:
-                scrubbers[field] = global_scrubbers[type(field)]
-
-        scrubbers.update(_get_model_scrubbers(model_class))
-
-        # Filter out all fields marked as "to be kept"
-        scrubbers_without_kept_fields = {}
-        for field, scrubbing_method in scrubbers.items():
-            if scrubbing_method != Keep:
-                scrubbers_without_kept_fields[field] = scrubbing_method
-        scrubbers = scrubbers_without_kept_fields
-
-        if not scrubbers:
-            return
-
-        realized_scrubbers = _filter_out_disabled(_call_callables(scrubbers))
-
-        self.stdout.write(f"Scrubbing {model_class._meta.label} with {realized_scrubbers}")
-
-        try:
-            if is_primary_key_integer(model_class=model_class):
-                model_class.objects.annotate(
-                    mod_pk=F("pk") % settings_with_fallback("SCRUBBER_ENTRIES_PER_PROVIDER"),
-                ).update(**realized_scrubbers)
-            else:
-                model_class.objects.annotate(
-                    mod_pk=StringToInt(F("pk")) % settings_with_fallback("SCRUBBER_ENTRIES_PER_PROVIDER"),
-                ).update(**realized_scrubbers)
-        except IntegrityError as e:
-            raise CommandError(
-                f"Integrity error while scrubbing {model_class} ({e}); maybe increase SCRUBBER_ENTRIES_PER_PROVIDER?",
-            ) from e
-        except DataError as e:
-            raise CommandError(f"DataError while scrubbing {model_class} ({e})") from e
-
-
-def is_primary_key_integer(model_class: Model):
-    # checks if the primary key of a model is an integer or integer-derived (e.g. AutoField) field
-    for field in model_class._meta.concrete_fields:
-        if field.primary_key is True:
-            return isinstance(field, IntegerField)
-    raise Exception("no primary key defined in model")
-
-
-def _call_callables(d):
-    """
-    Helper to realize lazy scrubbers, like Faker, or global field-type scrubbers
-    """
-    return {k.name: (v(k) if callable(v) else v) for k, v in d.items()}
-
-
-def _parse_scrubber_class_from_string(path: str):
-    """
-    Takes a string to a certain scrubber class and returns a python class definition - not an instance.
-    """
-    try:
-        module_name, class_name = path.rsplit(".", 1)
-        module = importlib.import_module(module_name)
-        return getattr(module, class_name)
-    except (ImportError, ValueError) as e:
-        raise ImportError(f'Mapped scrubber class "{path}" could not be found.') from e
-
-
-def _get_model_scrubbers(model):
-    # Get model-scrubber-mapping from settings
-    scrubber_mapping = settings_with_fallback("SCRUBBER_MAPPING")
-
-    # Initialise scrubber list
-    scrubbers = {}
-
-    # Check if model has a settings-defined...
-    if model._meta.label in scrubber_mapping:
-        scrubber_cls = _parse_scrubber_class_from_string(scrubber_mapping[model._meta.label])
-    # If not...
-    else:
-        # Try to get the scrubber metaclass from the given model
-        try:
-            scrubber_cls = model.Scrubbers
-        except AttributeError:
-            return scrubbers  # no model-specific scrubbers
-
-    # Get field mappings from scrubber class
-    for k, v in _get_fields(scrubber_cls):
-        try:
-            field = model._meta.get_field(k)
-            scrubbers[field] = v
-        except FieldDoesNotExist:
-            warnings.warn(f"Scrubber defined for {model.__name__}.{k} but field does not exist", stacklevel=2)
-
-    # Return scrubber-field-mapping
-    return scrubbers
-
-
-def _get_fields(d):
-    """
-    Helper to get "normal" (i.e.: non-magic and non-dunder) instance attributes.
-    Returns an iterator of (field_name, field) tuples.
-    """
-    return ((k, v) for k, v in getmembers(d) if not k.startswith("_"))
-
-
-def _filter_out_disabled(d):
-    """
-    Helper to remove Nones (actually any false-like type) from the scrubbers.
-    This is needed so we can disable global scrubbers in a per-model basis.
-    """
-    return {k: v for k, v in d.items() if v}
+        service_class = _get_scrubber_service_class()
+        service = service_class(stdout=self.stdout, stderr=self.stderr)
+        service.run(
+            model=kwargs.get("model"),
+            keep_sessions=kwargs.get("keep_sessions", False),
+            remove_fake_data=kwargs.get("remove_fake_data", False),
+        )

--- a/django_scrubber/services/scrubber.py
+++ b/django_scrubber/services/scrubber.py
@@ -1,0 +1,283 @@
+import importlib
+import logging
+import warnings
+from inspect import getmembers
+
+from django.apps import apps
+from django.conf import settings
+from django.contrib.sessions.models import Session
+from django.core.exceptions import FieldDoesNotExist
+from django.core.management.base import CommandError
+from django.db.models import F, IntegerField, Model
+from django.db.models.expressions import Func
+from django.db.utils import DataError, IntegrityError
+
+from django_scrubber import settings_with_fallback
+from django_scrubber.models import FakeData
+from django_scrubber.scrubbers import Keep
+from django_scrubber.services.validator import ScrubberValidatorService
+
+logger = logging.getLogger("django_scrubber")
+
+
+class StringToInt(Func):
+    """
+    database-specific implementations for reproducible conversion of a field value to an integer
+    """
+
+    def as_sqlite(self, compiler, connection, **extra_context):
+        return self.as_sql(
+            compiler,
+            connection,
+            template="ABS(CAST(SUBSTR(UPPER(MD5(CAST(%(expressions)s AS VARCHAR))), 1, 16) AS BIGINT))",
+            **extra_context,
+        )
+
+    def as_mysql(self, compiler, connection, **extra_context):
+        return self.as_sql(
+            compiler,
+            connection,
+            template="ABS(CONV(SUBSTRING(MD5(CONCAT('x', %(expressions)s)), 1, 16), 16, 10))",
+            **extra_context,
+        )
+
+    def as_postgresql(self, compiler, connection, **extra_context):
+        return self.as_sql(
+            compiler,
+            connection,
+            template="ABS(CAST(CAST(('x' || MD5(CAST(%(expressions)s AS VARCHAR))) AS BIT(64)) AS BIGINT))",
+            **extra_context,
+        )
+
+
+class ScrubberService:
+    """
+    Orchestrates the whole scrubbing process. The ``scrub_data`` management command delegates to an instance of
+    this class (or a subclass thereof, configured via the ``SCRUBBER_SERVICE_CLASS`` setting).
+
+    Subclass it and override :meth:`pre_scrub` / :meth:`post_scrub` to run custom logic before and/or after
+    scrubbing. Configuration (what to clean up) is not done here but through the ``SCRUBBER_*`` settings and the
+    command-line arguments, so the service stays purely about behaviour.
+    The default implementation reproduces the historic ``scrub_data`` behaviour exactly, so scrubbing works
+    out of the box without any additional configuration.
+    """
+
+    def __init__(self, *, stdout=None, stderr=None):
+        # stdout/stderr are the management command's output streams (may be None when used programmatically)
+        self.stdout = stdout
+        self.stderr = stderr
+        self.logger = logger
+
+    def pre_scrub(self) -> None:
+        """
+        Hook executed once before any data is scrubbed. Override in a subclass and call your steps
+        imperatively - their execution order is simply the order of your statements.
+        """
+
+    def post_scrub(self) -> None:
+        """
+        Hook executed once after all models have been scrubbed but before the admin-log/session/Faker-data
+        cleanup. Override in a subclass; see :meth:`pre_scrub` for ordering semantics.
+        """
+
+    def run(self, *, model: str | None = None, keep_sessions: bool = False, remove_fake_data: bool = False) -> bool:
+        """
+        Run the full scrubbing process. ``model``, ``keep_sessions`` and ``remove_fake_data`` mirror the
+        ``scrub_data`` command arguments.
+
+        Returns ``True`` when scrubbing ran and ``False`` when it was aborted (e.g. because ``DEBUG`` is off).
+        """
+        if not settings.DEBUG:
+            # avoid logger, otherwise we might silently fail if we're on live and logging is being sent somewhere else
+            self._write_stderr("This command should only be run with DEBUG=True, to avoid running on live systems")
+            return False
+
+        # Check STRICT mode
+        if settings_with_fallback("SCRUBBER_STRICT_MODE"):
+            validator = ScrubberValidatorService()
+            non_scrubbed_field_list = validator.process()
+            if len(non_scrubbed_field_list) > 0:
+                self._write_stderr(
+                    'When "SCRUBBER_STRICT_MODE" is enabled, you have to define a scrubbing policy '
+                    "for every text-based field.",
+                )
+                return False
+
+        global_scrubbers = settings_with_fallback("SCRUBBER_GLOBAL_SCRUBBERS")
+
+        # run only for selected model
+        if model is not None:
+            app_label, model_name = model.rsplit(".", 1)
+            try:
+                models = [apps.get_model(app_label=app_label, model_name=model_name)]
+            except LookupError as e:
+                raise CommandError("--model should be defined as <app_label>.<model_name>") from e
+
+        # run for all models of all apps
+        else:
+            models = apps.get_models()
+
+        # Custom pre-scrubbing
+        self.pre_scrub()
+
+        scrubber_apps_list = settings_with_fallback("SCRUBBER_APPS_LIST")
+        for model_class in models:
+            self._scrub_model(model_class, scrubber_apps_list, global_scrubbers)
+
+        # Custom post-scrubbing
+        self.post_scrub()
+
+        # Truncate django admin log (may contain user-related data)
+        if settings_with_fallback("SCRUBBER_CLEAR_DJANGO_ADMIN_LOG"):
+            self._clear_django_admin_log()
+
+        # Truncate session data
+        if not keep_sessions:
+            Session.objects.all().delete()
+
+        # Truncate Faker data
+        if remove_fake_data:
+            FakeData.objects.all().delete()
+
+        return True
+
+    def _clear_django_admin_log(self) -> None:
+        # django.contrib.admin is not a hard dependency, so only touch it when it is actually installed
+        if not apps.is_installed("django.contrib.admin"):
+            self.logger.warning(
+                "SCRUBBER_CLEAR_DJANGO_ADMIN_LOG is enabled but 'django.contrib.admin' is not in "
+                "INSTALLED_APPS; skipping admin log cleanup.",
+            )
+            return
+
+        from django.contrib.admin.models import LogEntry  # noqa: PLC0415
+
+        LogEntry.objects.all().delete()
+
+    def _write_stdout(self, message: str) -> None:
+        if self.stdout is not None:
+            self.stdout.write(message)
+
+    def _write_stderr(self, message: str) -> None:
+        if self.stderr is not None:
+            self.stderr.write(message)
+
+    def _scrub_model(self, model_class, scrubber_apps_list, global_scrubbers):
+        if (
+            model_class._meta.proxy
+            or (settings_with_fallback("SCRUBBER_SKIP_UNMANAGED") and not model_class._meta.managed)
+            or (scrubber_apps_list and model_class._meta.app_config.name not in scrubber_apps_list)
+        ):
+            return
+
+        scrubbers = {}
+        for field in model_class._meta.fields:
+            if field.name in global_scrubbers:
+                scrubbers[field] = global_scrubbers[field.name]
+            elif type(field) in global_scrubbers:
+                scrubbers[field] = global_scrubbers[type(field)]
+
+        scrubbers.update(_get_model_scrubbers(model_class))
+
+        # Filter out all fields marked as "to be kept"
+        scrubbers_without_kept_fields = {}
+        for field, scrubbing_method in scrubbers.items():
+            if scrubbing_method != Keep:
+                scrubbers_without_kept_fields[field] = scrubbing_method
+        scrubbers = scrubbers_without_kept_fields
+
+        if not scrubbers:
+            return
+
+        realized_scrubbers = _filter_out_disabled(_call_callables(scrubbers))
+
+        self._write_stdout(f"Scrubbing {model_class._meta.label} with {realized_scrubbers}")
+
+        try:
+            if is_primary_key_integer(model_class=model_class):
+                model_class.objects.annotate(
+                    mod_pk=F("pk") % settings_with_fallback("SCRUBBER_ENTRIES_PER_PROVIDER"),
+                ).update(**realized_scrubbers)
+            else:
+                model_class.objects.annotate(
+                    mod_pk=StringToInt(F("pk")) % settings_with_fallback("SCRUBBER_ENTRIES_PER_PROVIDER"),
+                ).update(**realized_scrubbers)
+        except IntegrityError as e:
+            raise CommandError(
+                f"Integrity error while scrubbing {model_class} ({e}); maybe increase SCRUBBER_ENTRIES_PER_PROVIDER?",
+            ) from e
+        except DataError as e:
+            raise CommandError(f"DataError while scrubbing {model_class} ({e})") from e
+
+
+def is_primary_key_integer(model_class: Model):
+    # checks if the primary key of a model is an integer or integer-derived (e.g. AutoField) field
+    for field in model_class._meta.concrete_fields:
+        if field.primary_key is True:
+            return isinstance(field, IntegerField)
+    raise Exception("no primary key defined in model")
+
+
+def _call_callables(d):
+    """
+    Helper to realize lazy scrubbers, like Faker, or global field-type scrubbers
+    """
+    return {k.name: (v(k) if callable(v) else v) for k, v in d.items()}
+
+
+def _parse_scrubber_class_from_string(path: str):
+    """
+    Takes a string to a certain scrubber class and returns a python class definition - not an instance.
+    """
+    try:
+        module_name, class_name = path.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        return getattr(module, class_name)
+    except (ImportError, ValueError) as e:
+        raise ImportError(f'Mapped scrubber class "{path}" could not be found.') from e
+
+
+def _get_model_scrubbers(model):
+    # Get model-scrubber-mapping from settings
+    scrubber_mapping = settings_with_fallback("SCRUBBER_MAPPING")
+
+    # Initialise scrubber list
+    scrubbers = {}
+
+    # Check if model has a settings-defined...
+    if model._meta.label in scrubber_mapping:
+        scrubber_cls = _parse_scrubber_class_from_string(scrubber_mapping[model._meta.label])
+    # If not...
+    else:
+        # Try to get the scrubber metaclass from the given model
+        try:
+            scrubber_cls = model.Scrubbers
+        except AttributeError:
+            return scrubbers  # no model-specific scrubbers
+
+    # Get field mappings from scrubber class
+    for k, v in _get_fields(scrubber_cls):
+        try:
+            field = model._meta.get_field(k)
+            scrubbers[field] = v
+        except FieldDoesNotExist:
+            warnings.warn(f"Scrubber defined for {model.__name__}.{k} but field does not exist", stacklevel=2)
+
+    # Return scrubber-field-mapping
+    return scrubbers
+
+
+def _get_fields(d):
+    """
+    Helper to get "normal" (i.e.: non-magic and non-dunder) instance attributes.
+    Returns an iterator of (field_name, field) tuples.
+    """
+    return ((k, v) for k, v in getmembers(d) if not k.startswith("_"))
+
+
+def _filter_out_disabled(d):
+    """
+    Helper to remove Nones (actually any false-like type) from the scrubbers.
+    This is needed so we can disable global scrubbers in a per-model basis.
+    """
+    return {k: v for k, v in d.items() if v}

--- a/django_scrubber/services/scrubber.py
+++ b/django_scrubber/services/scrubber.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 import warnings
 from inspect import getmembers
@@ -11,13 +10,14 @@ from django.core.management.base import CommandError
 from django.db.models import F, IntegerField, Model
 from django.db.models.expressions import Func
 from django.db.utils import DataError, IntegrityError
+from django.utils.module_loading import import_string
 
 from django_scrubber import settings_with_fallback
 from django_scrubber.models import FakeData
 from django_scrubber.scrubbers import Keep
 from django_scrubber.services.validator import ScrubberValidatorService
 
-logger = logging.getLogger("django_scrubber")
+logger = logging.getLogger(__name__)
 
 
 class StringToInt(Func):
@@ -105,20 +105,23 @@ class ScrubberService:
 
         global_scrubbers = settings_with_fallback("SCRUBBER_GLOBAL_SCRUBBERS")
 
-        # run only for selected model
-        if model is not None:
-            app_label, model_name = model.rsplit(".", 1)
-            try:
-                models = [apps.get_model(app_label=app_label, model_name=model_name)]
-            except LookupError as e:
-                raise CommandError("--model should be defined as <app_label>.<model_name>") from e
+        # A --model-scoped run only touches the requested model; a full run scrubs every model.
+        scrub_all_models = model is None
+
+        # Custom pre-scrubbing. Runs before any data is scrubbed - and before the model list is
+        # materialized - so a subclass may register/load additional models to be picked up below.
+        self.pre_scrub()
 
         # run for all models of all apps
-        else:
+        if scrub_all_models:
             models = apps.get_models()
-
-        # Custom pre-scrubbing
-        self.pre_scrub()
+        # run only for the selected model
+        else:
+            try:
+                app_label, model_name = model.rsplit(".", 1)
+                models = [apps.get_model(app_label=app_label, model_name=model_name)]
+            except (LookupError, ValueError) as e:
+                raise CommandError("--model should be defined as <app_label>.<model_name>") from e
 
         scrubber_apps_list = settings_with_fallback("SCRUBBER_APPS_LIST")
         for model_class in models:
@@ -127,13 +130,16 @@ class ScrubberService:
         # Custom post-scrubbing
         self.post_scrub()
 
-        # Truncate django admin log (may contain user-related data)
-        if settings_with_fallback("SCRUBBER_CLEAR_DJANGO_ADMIN_LOG"):
-            self._clear_django_admin_log()
+        # The following are global side effects that are not tied to a single model. Only run them
+        # on a full scrub, so a --model-scoped run never wipes global tables outside its scope.
+        if scrub_all_models:
+            # Truncate django admin log (may contain user-related data)
+            if settings_with_fallback("SCRUBBER_CLEAR_DJANGO_ADMIN_LOG"):
+                self._clear_django_admin_log()
 
-        # Truncate session data
-        if not keep_sessions:
-            Session.objects.all().delete()
+            # Truncate session data
+            if not keep_sessions:
+                Session.objects.all().delete()
 
         # Truncate Faker data
         if remove_fake_data:
@@ -230,10 +236,8 @@ def _parse_scrubber_class_from_string(path: str):
     Takes a string to a certain scrubber class and returns a python class definition - not an instance.
     """
     try:
-        module_name, class_name = path.rsplit(".", 1)
-        module = importlib.import_module(module_name)
-        return getattr(module, class_name)
-    except (ImportError, ValueError) as e:
+        return import_string(path)
+    except ImportError as e:
         raise ImportError(f'Mapped scrubber class "{path}" could not be found.') from e
 
 

--- a/django_scrubber/services/validator.py
+++ b/django_scrubber/services/validator.py
@@ -19,7 +19,7 @@ class ScrubberValidatorService:
         raise ValueError("Invalid pattern type")
 
     def process(self) -> dict:
-        from django_scrubber.management.commands.scrub_data import _get_model_scrubbers  # noqa: PLC0415
+        from django_scrubber.services.scrubber import _get_model_scrubbers  # noqa: PLC0415
 
         scrubber_required_field_types = settings_with_fallback("SCRUBBER_REQUIRED_FIELD_TYPES")
         model_whitelist = settings_with_fallback("SCRUBBER_REQUIRED_FIELD_MODEL_WHITELIST")

--- a/django_scrubber/tests/services/test_validator.py
+++ b/django_scrubber/tests/services/test_validator.py
@@ -32,7 +32,7 @@ class ScrubberValidatorServiceTest(TestCase):
 
     @override_settings(SCRUBBER_MAPPING={"auth.User": "FullUserScrubbers"})
     @mock.patch(
-        "django_scrubber.management.commands.scrub_data._parse_scrubber_class_from_string",
+        "django_scrubber.services.scrubber._parse_scrubber_class_from_string",
         return_value=FullUserScrubbers,
     )
     def test_process_scrubber_mapper_all_fields(self, mocked_function):
@@ -46,7 +46,7 @@ class ScrubberValidatorServiceTest(TestCase):
 
     @override_settings(SCRUBBER_MAPPING={"auth.User": "PartUserScrubbers"})
     @mock.patch(
-        "django_scrubber.management.commands.scrub_data._parse_scrubber_class_from_string",
+        "django_scrubber.services.scrubber._parse_scrubber_class_from_string",
         return_value=PartUserScrubbers,
     )
     def test_process_scrubber_mapper_some_fields(self, mocked_function):

--- a/django_scrubber/tests/test_scrub_data.py
+++ b/django_scrubber/tests/test_scrub_data.py
@@ -7,12 +7,17 @@ from uuid import uuid4
 from django.contrib.auth import get_user_model
 from django.contrib.sessions.models import Session
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.db.models import Value
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from django_scrubber import scrubbers
-from django_scrubber.management.commands.scrub_data import _get_model_scrubbers, _parse_scrubber_class_from_string
+from django_scrubber.management.commands.scrub_data import (
+    _get_model_scrubbers,
+    _get_scrubber_service_class,
+    _parse_scrubber_class_from_string,
+)
 from django_scrubber.models import FakeData
 from django_scrubber.services.scrubber import ScrubberService
 
@@ -235,3 +240,57 @@ class TestScrubData(TestCase):
             call_command("scrub_data", "--remove-fake-data", stdout=StringIO())
 
         self.assertFalse(FakeData.objects.exists())
+
+    def test_model_scoped_run_keeps_sessions(self):
+        # a --model-scoped run must not wipe global tables (here: sessions) outside its scope
+        with self.settings(DEBUG=True, SCRUBBER_GLOBAL_SCRUBBERS={"first_name": scrubbers.Faker("first_name")}):
+            call_command("scrub_data", "--model", "auth.User", stdout=StringIO())
+
+        self.assertTrue(Session.objects.filter(pk=self.session.pk).exists())
+
+    def test_model_scoped_run_keeps_django_admin_log(self):
+        # a --model-scoped run must not truncate the admin log even when the setting is enabled
+        fake_admin_models = ModuleType("django.contrib.admin.models")
+        fake_admin_models.LogEntry = MagicMock()
+        with (
+            self.settings(DEBUG=True, SCRUBBER_CLEAR_DJANGO_ADMIN_LOG=True),
+            patch("django_scrubber.services.scrubber.apps.is_installed", return_value=True),
+            patch.dict("sys.modules", {"django.contrib.admin.models": fake_admin_models}),
+        ):
+            call_command("scrub_data", "--model", "auth.User", stdout=StringIO())
+
+        fake_admin_models.LogEntry.objects.all.return_value.delete.assert_not_called()
+
+    def test_model_without_dot_raises_command_error(self):
+        # --model without an <app_label>.<model_name> separator must raise a helpful CommandError,
+        # not a raw ValueError from the tuple unpack
+        with self.settings(DEBUG=True), self.assertRaisesRegex(CommandError, "app_label"):
+            call_command("scrub_data", "--model", "User", stdout=StringIO())
+
+    def test_unknown_model_raises_command_error(self):
+        with self.settings(DEBUG=True), self.assertRaisesRegex(CommandError, "app_label"):
+            call_command("scrub_data", "--model", "auth.DoesNotExist", stdout=StringIO())
+
+    def test_handle_returns_false_when_aborted(self):
+        # programmatic callers rely on call_command() returning False when the run is aborted
+        with self.settings(DEBUG=False):
+            result = call_command("scrub_data", stdout=StringIO(), stderr=StringIO())
+
+        self.assertIs(result, False)
+
+    def test_handle_returns_none_on_success(self):
+        with self.settings(DEBUG=True, SCRUBBER_GLOBAL_SCRUBBERS={"first_name": scrubbers.Faker("first_name")}):
+            result = call_command("scrub_data", stdout=StringIO())
+
+        self.assertIsNone(result)
+
+    def test_get_scrubber_service_class_invalid_path_raises_command_error(self):
+        with self.settings(SCRUBBER_SERVICE_CLASS="not_a_valid_dotted_path"), self.assertRaises(CommandError):
+            _get_scrubber_service_class()
+
+    def test_get_scrubber_service_class_missing_attribute_raises_command_error(self):
+        with (
+            self.settings(SCRUBBER_SERVICE_CLASS="django_scrubber.services.scrubber.DoesNotExist"),
+            self.assertRaises(CommandError),
+        ):
+            _get_scrubber_service_class()

--- a/django_scrubber/tests/test_scrub_data.py
+++ b/django_scrubber/tests/test_scrub_data.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from io import StringIO
-from unittest.mock import patch
+from types import ModuleType
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.contrib.auth import get_user_model
@@ -12,8 +13,22 @@ from django.utils import timezone
 
 from django_scrubber import scrubbers
 from django_scrubber.management.commands.scrub_data import _get_model_scrubbers, _parse_scrubber_class_from_string
+from django_scrubber.models import FakeData
+from django_scrubber.services.scrubber import ScrubberService
 
 User = get_user_model()
+
+# Records (hook_name, first_name-seen-in-db) tuples so tests can assert hooks run in the expected order and
+# at the expected point in the process (before/after the actual scrubbing).
+hook_calls: list[tuple[str, str]] = []
+
+
+class HookRecordingScrubberService(ScrubberService):
+    def pre_scrub(self):
+        hook_calls.append(("pre", User.objects.get().first_name))
+
+    def post_scrub(self):
+        hook_calls.append(("post", User.objects.get().first_name))
 
 
 class TestScrubData(TestCase):
@@ -21,6 +36,10 @@ class TestScrubData(TestCase):
     DEFAULT_SESSION_DATA = "default_test_session_data"
 
     def setUp(self):
+        # Faker caches which providers it has already populated on the class itself, but each test rolls back
+        # its transaction and empties the FakeData table. Reset the cache so every test repopulates it.
+        scrubbers.Faker.INITIALIZED_PROVIDERS.clear()
+
         # model with integer pk
         self.user = User.objects.create(first_name=self.DEFAULT_USER_FIRST_NAME)
 
@@ -121,10 +140,10 @@ class TestScrubData(TestCase):
     def test_get_model_scrubbers_mapper_from_settings_used(self):
         with (
             patch(
-                "django_scrubber.management.commands.scrub_data._parse_scrubber_class_from_string",
+                "django_scrubber.services.scrubber._parse_scrubber_class_from_string",
                 return_value={},
             ) as mocked_method,
-            patch("django_scrubber.management.commands.scrub_data._get_fields", return_value=[]),
+            patch("django_scrubber.services.scrubber._get_fields", return_value=[]),
         ):
             test_scrubbers = _get_model_scrubbers(User)
         mocked_method.assert_called_once()
@@ -141,3 +160,78 @@ class TestScrubData(TestCase):
     def test_parse_scrubber_class_from_string_path_no_separator(self):
         with self.assertRaises(ImportError):
             _parse_scrubber_class_from_string("broken_path")
+
+    def test_pre_and_post_scrub_hooks_called_in_order(self):
+        hook_calls.clear()
+        with self.settings(
+            DEBUG=True,
+            SCRUBBER_GLOBAL_SCRUBBERS={"first_name": scrubbers.Faker("first_name")},
+            SCRUBBER_SERVICE_CLASS="django_scrubber.tests.test_scrub_data.HookRecordingScrubberService",
+        ):
+            call_command("scrub_data", stdout=StringIO())
+
+        # both hooks ran, pre before post
+        self.assertEqual([name for name, _ in hook_calls], ["pre", "post"])
+        # pre_scrub runs before scrubbing, so it still sees the original value...
+        self.assertEqual(hook_calls[0][1], self.DEFAULT_USER_FIRST_NAME)
+        # ...while post_scrub runs afterwards and sees the scrubbed value
+        self.assertNotEqual(hook_calls[1][1], self.DEFAULT_USER_FIRST_NAME)
+
+    def test_default_service_does_not_define_hooks(self):
+        # backwards compatibility: the default service must not run any custom logic
+        hook_calls.clear()
+        with self.settings(DEBUG=True):
+            call_command("scrub_data", stdout=StringIO())
+        self.assertEqual(hook_calls, [])
+
+    def test_clear_django_admin_log_when_enabled(self):
+        # django.contrib.admin is not installed in the test project, so we pretend it is and mock the
+        # lazily-imported LogEntry
+        fake_admin_models = ModuleType("django.contrib.admin.models")
+        fake_admin_models.LogEntry = MagicMock()
+        with (
+            self.settings(DEBUG=True, SCRUBBER_CLEAR_DJANGO_ADMIN_LOG=True),
+            patch("django_scrubber.services.scrubber.apps.is_installed", return_value=True),
+            patch.dict("sys.modules", {"django.contrib.admin.models": fake_admin_models}),
+        ):
+            call_command("scrub_data", stdout=StringIO())
+
+        fake_admin_models.LogEntry.objects.all.return_value.delete.assert_called_once()
+
+    def test_clear_django_admin_log_skipped_when_admin_not_installed(self):
+        # graceful degradation: enabling the setting without django.contrib.admin installed must not raise
+        fake_admin_models = ModuleType("django.contrib.admin.models")
+        fake_admin_models.LogEntry = MagicMock()
+        with (
+            self.settings(DEBUG=True, SCRUBBER_CLEAR_DJANGO_ADMIN_LOG=True),
+            patch("django_scrubber.services.scrubber.apps.is_installed", return_value=False),
+            patch.dict("sys.modules", {"django.contrib.admin.models": fake_admin_models}),
+        ):
+            call_command("scrub_data", stdout=StringIO())
+
+        fake_admin_models.LogEntry.objects.all.return_value.delete.assert_not_called()
+
+    def test_django_admin_log_kept_by_default(self):
+        # backwards compatibility: the admin log must not be touched unless SCRUBBER_CLEAR_DJANGO_ADMIN_LOG is set
+        fake_admin_models = ModuleType("django.contrib.admin.models")
+        fake_admin_models.LogEntry = MagicMock()
+        with (
+            self.settings(DEBUG=True),
+            patch.dict("sys.modules", {"django.contrib.admin.models": fake_admin_models}),
+        ):
+            call_command("scrub_data", stdout=StringIO())
+
+        fake_admin_models.LogEntry.objects.all.return_value.delete.assert_not_called()
+
+    def test_fake_data_kept_by_default(self):
+        # backwards compatibility: preprocessed Faker data is kept unless --remove-fake-data is passed
+        with self.settings(DEBUG=True, SCRUBBER_GLOBAL_SCRUBBERS={"first_name": scrubbers.Faker("first_name")}):
+            call_command("scrub_data", stdout=StringIO())
+
+        self.assertTrue(FakeData.objects.exists())
+
+    def test_remove_fake_data_flag_truncates_fake_data(self):
+        with self.settings(DEBUG=True, SCRUBBER_GLOBAL_SCRUBBERS={"first_name": scrubbers.Faker("first_name")}):
+            call_command("scrub_data", "--remove-fake-data", stdout=StringIO())
+
+        self.assertFalse(FakeData.objects.exists())


### PR DESCRIPTION
### Scrubber Service Wrapper

Introduces a pluggable `ScrubberService` that the `scrub_data` command delegates
to, configurable via `SCRUBBER_SERVICE_CLASS`, with `pre_scrub()` / `post_scrub()`
hooks and an optional `SCRUBBER_CLEAR_DJANGO_ADMIN_LOG` cleanup.

**Behavior change**
- `scrub_data --model <app.Model>` no longer truncates session data. Session
  cleanup is global (model-independent) and now runs only on a full, unscoped
  scrub. Previously a single-model run also wiped all sessions.

**Bug fix**
- `scrub_data --model <value>` without a `.` separator (e.g. `--model User`) now
  raises a clear `CommandError` instead of an unhandled `ValueError`.

Closes #37 