### PR TITLE
feat: add support for django 6.1

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -33,6 +33,7 @@ jobs:
           - "4.2"
           - "5.2"
           - "6.0"
+          - "6.1"
         database:
           - sqlite
           - mysql
@@ -45,6 +46,10 @@ jobs:
           - django: "6.0"
             python-version: "3.10"
           - django: "6.0"
+            python-version: "3.11"
+          - django: "6.1"
+            python-version: "3.10"
+          - django: "6.1"
             python-version: "3.11"
 
     services:

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,7 +6,7 @@
   module_description: "Data anonymizer for Django"
   module_keywords:
     ["django", "data protection", "scrubber", "scrub", "anonymize", "gdpr"]
-  dependencies: ["Faker>=20.0.0", "Django>=4.2,<6.1"]
+  dependencies: ["Faker>=20.0.0", "Django>=4.2,<6.2"]
   max_line_length: 119
   changelog_since_tag: "v4.1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["Faker>=20.0.0", "Django>=4.2,<6.1"]
+dependencies = ["Faker>=20.0.0", "Django>=4.2,<6.2"]
 
 [project.urls]
 Homepage = "https://github.com/RegioHelden/django-scrubber"


### PR DESCRIPTION
🤖 Not typed by hand

Closes #289

Widens the Django constraint to `<6.2` and adds 6.1 to the CI matrix.

Verified: full suite against Django 6.1 on sqlite, 44 tests, OK (3 skipped, the vendor-specific ones). MySQL and Postgres are left to CI.

`requirements-test.txt` still pins `django==6.0.7` — renovate PR #286 covers that — and `COVERAGE_DJANGO_VERSION` stays at `6.0`.
